### PR TITLE
Initialize project skeleton and Ollama wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# personal_assistant
+# Personal Assistant
+
+This project is an on‑prem personal AI assistant. Phase 1 provides the
+foundation for running a local model through [Ollama](https://ollama.ai/).
+
+## Setup
+
+1. Install Python 3.11 or later and create a virtual environment::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+
+2. Install Ollama and download the Llama 3.1 8B model. Follow the
+   instructions at <https://ollama.ai>.
+
+3. Update `configs/config.yaml` if your Ollama service runs on a different
+   host or port.
+
+4. Test the connection:
+
+    python -m src.ollama_service
+
+This should print the model's response to a simple prompt.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,2 @@
+ollama_base_url: http://localhost:11434
+model: llama3-8b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyyaml

--- a/src/ollama_service.py
+++ b/src/ollama_service.py
@@ -1,0 +1,26 @@
+import requests
+import yaml
+from pathlib import Path
+
+
+def load_config(config_path: str | Path = 'configs/config.yaml') -> dict:
+    """Load YAML configuration."""
+    with open(config_path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def generate(prompt: str, config: dict | None = None) -> str:
+    """Send a prompt to the Ollama API and return the response."""
+    cfg = config or load_config()
+    url = cfg.get('ollama_base_url', 'http://localhost:11434') + '/api/generate'
+    model = cfg.get('model', 'llama3-8b')
+    response = requests.post(url, json={'model': model, 'prompt': prompt})
+    response.raise_for_status()
+    data = response.json()
+    return data.get('response', '')
+
+
+if __name__ == '__main__':
+    cfg = load_config()
+    answer = generate('Hello, how are you?', config=cfg)
+    print(answer)


### PR DESCRIPTION
## Summary
- set up README with setup steps
- specify requirements for requests and PyYAML
- add minimal config.yaml for Ollama settings
- implement basic Python wrapper for Ollama API

## Testing
- `pip install requests pyyaml`
- `python -m src.ollama_service` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684a93114da883299d319dcdba129ca2